### PR TITLE
Exclude global scopes from reordering.

### DIFF
--- a/src/Http/Controllers/SortableController.php
+++ b/src/Http/Controllers/SortableController.php
@@ -24,7 +24,8 @@ class SortableController extends Controller
         // dump($request->id);
         // dump([$sort_column => $index]);
 
-        $model::find($request->id)
+        $model::withoutGlobalScopes()
+            ->find($request->id)
             ->update([$sort_column => $index]);
 
         $paginator = $this->paginator(

--- a/src/SortableObserver.php
+++ b/src/SortableObserver.php
@@ -32,7 +32,8 @@ class SortableObserver
             $sort_column = $model::sortColumnName();        // 'sort_order'
             $sort_on = $model->sortOn();
 
-            $res = $model::where($sort_on)
+            $res = $model::withoutGlobalScopes()
+                ->where($sort_on)
                 ->orderBy($sort_column, 'ASC');
 
             if ($model->id) {


### PR DESCRIPTION
Resolves issue when moving unpublished playlists within Nova.